### PR TITLE
feat: add support for PostgreSQL credentials from existing secrets

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -45,6 +45,30 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ include "homebox.fullname" . }}
+          {{- if and (eq .Values.env.HBOX_DATABASE_DRIVER "postgres") (not .Values.postgresql.enabled) }}
+          env:
+            {{- if and .Values.externalPostgresql.auth.username (kindIs "map" .Values.externalPostgresql.auth.username) }}
+            - name: HBOX_DATABASE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalPostgresql.auth.username.existingSecret }}
+                  key: {{ .Values.externalPostgresql.auth.username.existingSecretKey }}
+            {{- end }}
+            {{- if and .Values.externalPostgresql.auth.password (kindIs "map" .Values.externalPostgresql.auth.password) }}
+            - name: HBOX_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalPostgresql.auth.password.existingSecret }}
+                  key: {{ .Values.externalPostgresql.auth.password.existingSecretKey }}
+            {{- end }}
+            {{- if and .Values.externalPostgresql.auth.database (kindIs "map" .Values.externalPostgresql.auth.database) }}
+            - name: HBOX_DATABASE_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalPostgresql.auth.database.existingSecret }}
+                  key: {{ .Values.externalPostgresql.auth.database.existingSecretKey }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -17,9 +17,15 @@ stringData:
     {{- else }}
   HBOX_DATABASE_HOST: {{ .Values.externalPostgresql.host | quote }}
   HBOX_DATABASE_PORT: {{ .Values.externalPostgresql.port | quote }}
+  {{- if and .Values.externalPostgresql.auth.username (kindIs "string" .Values.externalPostgresql.auth.username) }}
   HBOX_DATABASE_USERNAME: {{ .Values.externalPostgresql.auth.username | quote }}
+  {{- end }}
+  {{- if and .Values.externalPostgresql.auth.password (kindIs "string" .Values.externalPostgresql.auth.password) }}
   HBOX_DATABASE_PASSWORD: {{ .Values.externalPostgresql.auth.password | quote }}
+  {{- end }}
+  {{- if and .Values.externalPostgresql.auth.database (kindIs "string" .Values.externalPostgresql.auth.database) }}
   HBOX_DATABASE_DATABASE: {{ .Values.externalPostgresql.auth.database | quote }}
+  {{- end }}
     {{- end }}
   {{- else }}
   HBOX_DATABASE_DRIVER: "sqlite3"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -88,9 +88,21 @@ externalPostgresql:
   host: postgres
   port: 5432
   auth:
-    username: external-homebox-user
-    password: external-homebox-password
-    database: external-homebox-db
+    # You can use string values:
+    # username: external-homebox-user
+    # password: external-homebox-password
+    # database: external-homebox-db
+    
+    # Or reference existing secrets:
+    # username:
+    #   existingSecret: ""
+    #   existingSecretKey: "username"
+    # password:
+    #   existingSecret: ""
+    #   existingSecretKey: "password"
+    # database:
+    #   existingSecret: ""
+    #   existingSecretKey: "database"
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []


### PR DESCRIPTION
This PR adds support for PostgreSQL credentials from existing secrets while keeping backwards compatibility.

In the values file, you can now specify a hardcoded string or a `existingSecret` and `existingSecretKey` for your database name, username and password.